### PR TITLE
Fix unpredictable failure on iOS

### DIFF
--- a/src/share-file.ios.ts
+++ b/src/share-file.ios.ts
@@ -12,7 +12,6 @@ export class ShareFile {
 
     private controller: UIDocumentInteractionController;
 
-
     open(args: any): boolean {
         if (args.path) {
             try {

--- a/src/share-file.ios.ts
+++ b/src/share-file.ios.ts
@@ -10,14 +10,17 @@ export class ShareFile {
         }
     }
 
+    private controller: UIDocumentInteractionController;
+
+
     open(args: any): boolean {
         if (args.path) {
             try {
                 const appPath = this.getCurrentAppPath();
                 const path = args.path.replace("~", appPath);
 
-                const controller = UIDocumentInteractionController.interactionControllerWithURL(NSURL.fileURLWithPath(path));
-                controller.delegate = new UIDocumentInteractionControllerDelegateImpl2();
+                this.controller = UIDocumentInteractionController.interactionControllerWithURL(NSURL.fileURLWithPath(path));
+                this.controller.delegate = new UIDocumentInteractionControllerDelegateImpl2();
 
                 let rect;
                 if (args.rect) {
@@ -26,16 +29,16 @@ export class ShareFile {
                     rect = CGRectMake(0, 0, 0, 0);
                 }
 
-                if ( args.options ) {
-                    return controller.presentOptionsMenuFromRectInViewAnimated(
+                if (args.options) {
+                    return this.controller.presentOptionsMenuFromRectInViewAnimated(
                         rect,
-                        controller.delegate.documentInteractionControllerViewForPreview(controller),
+                        this.controller.delegate.documentInteractionControllerViewForPreview(this.controller),
                         args.animated ? true : false
                     );
                 } else {
-                    return controller.presentOpenInMenuFromRectInViewAnimated(
+                    return this.controller.presentOpenInMenuFromRectInViewAnimated(
                         rect,
-                        controller.delegate.documentInteractionControllerViewForPreview(controller),
+                        this.controller.delegate.documentInteractionControllerViewForPreview(this.controller),
                         args.animated ? true : false
                     );
                 }


### PR DESCRIPTION
Sometimes, iOS garbage collector deletes the UIDocumentInteractionController before the share sheet displays, which causes the share target to not get the file. This PR puts it in a class variable so that doesn't happen.