### PR TITLE
Use FileProvider for Android URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,26 @@ Send/Share files to other apps.
 
 Android Intent, IOS InteractionController:
 
-<img src="https://github.com/braune-digital/nativescript-share-file/blob/master/preview/preview-android.png?raw=true" width="250"> . <img src="https://github.com/braune-digital/nativescript-share-file/blob/master/preview/preview-ios.png?raw=true" width="250">
+<img src="https://github.com/braune-digital/nativescript-share-file/blob/master/preview/preview-android.png?raw=true" width="250"> .   <img src="https://github.com/braune-digital/nativescript-share-file/blob/master/preview/preview-ios.png?raw=true" width="250">
+
+
 
 ## Installation
 
 Install the plugin in your app.
 
-```
+~~~
 npm install nativescript-share-file
-```
+~~~
 
-### Android FileProvider
+### Android FileProvider Setup
 
 On Android, you must add a FileProvider definition and specify available files, which is documented [here](https://developer.android.com/reference/androidx/core/content/FileProvider#ProviderDefinition)
 
-## Usage
+## Usage 
 
 Info: Shared files should be in the `documents` path.
-
+	
 ```TypeScript
     import { ShareFile } from 'nativescript-share-file';
     import * as fs from 'tns-core-modules/file-system';
@@ -42,8 +44,8 @@ Info: Shared files should be in the `documents` path.
             this.file = fs.File.fromPath(this.path);
             this.shareFile = new ShareFile();
 
-            this.shareFile.open( {
-                path: this.path,
+            this.shareFile.open( { 
+                path: this.path, 
                 intentTitle: 'Open text file with:', // optional Android
                 rect: { // optional iPad
                     x: 110,
@@ -62,35 +64,33 @@ Info: Shared files should be in the `documents` path.
 ### Arguments
 
 #### path
-
 Path to the file which will be shared.
+
 
 `String`: Required
 
+
 #### intentTitle
+Title for the intent on Android. 
 
-Title for the intent on Android.
-
-`String`: (Optional)
+`String`: (Optional) 
 Default: `Open file:`.
 
+
 #### rect
+Positioning the view for iPads. On iPhones it's always shown on the bottom. 
 
-Positioning the view for iPads. On iPhones it's always shown on the bottom.
-
-`Object`: (Optional)
+`Object`: (Optional) 
 Default: `{x: 0, y: 0, width: 0, height: 0 }`.
 
 #### options
-
-Show additional opening options for iOS devices.
+Show additional opening options for iOS devices. 
 
 `Boolean`: (Optional)
 Default: `false`.
 
 #### animated
+Opening animation for iOS devices. 
 
-Opening animation for iOS devices.
-
-`Boolean`: (Optional)
+`Boolean`: (Optional) 
 Default: `false`.

--- a/README.md
+++ b/README.md
@@ -4,22 +4,24 @@ Send/Share files to other apps.
 
 Android Intent, IOS InteractionController:
 
-<img src="https://github.com/braune-digital/nativescript-share-file/blob/master/preview/preview-android.png?raw=true" width="250"> .   <img src="https://github.com/braune-digital/nativescript-share-file/blob/master/preview/preview-ios.png?raw=true" width="250">
-
-
+<img src="https://github.com/braune-digital/nativescript-share-file/blob/master/preview/preview-android.png?raw=true" width="250"> . <img src="https://github.com/braune-digital/nativescript-share-file/blob/master/preview/preview-ios.png?raw=true" width="250">
 
 ## Installation
 
 Install the plugin in your app.
 
-~~~
+```
 npm install nativescript-share-file
-~~~
+```
 
-## Usage 
+### Android FileProvider
+
+On Android, you must add a FileProvider definition and specify available files, which is documented [here](https://developer.android.com/reference/androidx/core/content/FileProvider#ProviderDefinition)
+
+## Usage
 
 Info: Shared files should be in the `documents` path.
-	
+
 ```TypeScript
     import { ShareFile } from 'nativescript-share-file';
     import * as fs from 'tns-core-modules/file-system';
@@ -40,8 +42,8 @@ Info: Shared files should be in the `documents` path.
             this.file = fs.File.fromPath(this.path);
             this.shareFile = new ShareFile();
 
-            this.shareFile.open( { 
-                path: this.path, 
+            this.shareFile.open( {
+                path: this.path,
                 intentTitle: 'Open text file with:', // optional Android
                 rect: { // optional iPad
                     x: 110,
@@ -60,33 +62,35 @@ Info: Shared files should be in the `documents` path.
 ### Arguments
 
 #### path
-Path to the file which will be shared.
 
+Path to the file which will be shared.
 
 `String`: Required
 
-
 #### intentTitle
-Title for the intent on Android. 
 
-`String`: (Optional) 
+Title for the intent on Android.
+
+`String`: (Optional)
 Default: `Open file:`.
 
-
 #### rect
-Positioning the view for iPads. On iPhones it's always shown on the bottom. 
 
-`Object`: (Optional) 
+Positioning the view for iPads. On iPhones it's always shown on the bottom.
+
+`Object`: (Optional)
 Default: `{x: 0, y: 0, width: 0, height: 0 }`.
 
 #### options
-Show additional opening options for iOS devices. 
+
+Show additional opening options for iOS devices.
 
 `Boolean`: (Optional)
 Default: `false`.
 
 #### animated
-Opening animation for iOS devices. 
 
-`Boolean`: (Optional) 
+Opening animation for iOS devices.
+
+`Boolean`: (Optional)
 Default: `false`.

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -4,6 +4,34 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@nativescript/core": {
+            "version": "6.5.20",
+            "resolved": "https://registry.npmjs.org/@nativescript/core/-/core-6.5.20.tgz",
+            "integrity": "sha512-wbCXi6Ez17e8Cn8VO5kBwSw6f+uJJfHNSraWK+0nziM3N595niyKao+Wl8Yj8hQQyPt6Vzpyxa9h2buyD347Xw==",
+            "dev": true,
+            "requires": {
+                "css-tree": "^1.0.0-alpha.37",
+                "nativescript-hook": "0.2.5",
+                "reduce-css-calc": "^2.1.6",
+                "semver": "6.3.0",
+                "tns-core-modules-widgets": "^6.5.10",
+                "tslib": "1.10.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "tslib": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+                    "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+                    "dev": true
+                }
+            }
+        },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -143,6 +171,22 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
+        "css-tree": {
+            "version": "1.0.0-alpha.39",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.39.tgz",
+            "integrity": "sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==",
+            "dev": true,
+            "requires": {
+                "mdn-data": "2.0.6",
+                "source-map": "^0.6.1"
+            }
+        },
+        "css-unit-converter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
+            "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
+            "dev": true
+        },
         "cycle": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
@@ -264,6 +308,12 @@
                 "esprima": "^4.0.0"
             }
         },
+        "mdn-data": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.6.tgz",
+            "integrity": "sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA==",
+            "dev": true
+        },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -293,6 +343,31 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
             "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
             "dev": true
+        },
+        "nativescript-hook": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/nativescript-hook/-/nativescript-hook-0.2.5.tgz",
+            "integrity": "sha512-ciGJtNbtMB2lGv8jAkUripkRjd3g8atX9VYPSt6e8PI6YPiOKeoma3xjcXoW66pFMYpHnfrbp6Mq9U/QtiQrVg==",
+            "dev": true,
+            "requires": {
+                "glob": "^6.0.1",
+                "mkdirp": "^0.5.1"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "6.0.4",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                    "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+                    "dev": true,
+                    "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
         },
         "ncp": {
             "version": "1.0.1",
@@ -327,6 +402,12 @@
             "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
             "dev": true
         },
+        "postcss-value-parser": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+            "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+            "dev": true
+        },
         "prompt": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
@@ -348,6 +429,16 @@
             "dev": true,
             "requires": {
                 "mute-stream": "~0.0.4"
+            }
+        },
+        "reduce-css-calc": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.7.tgz",
+            "integrity": "sha512-fDnlZ+AybAS3C7Q9xDq5y8A2z+lT63zLbynew/lur/IR24OQF5x98tfNwf79mzEdfywZ0a2wpM860FhFfMxZlA==",
+            "dev": true,
+            "requires": {
+                "css-unit-converter": "^1.1.1",
+                "postcss-value-parser": "^3.3.0"
             }
         },
         "resolve": {
@@ -380,6 +471,12 @@
             "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
             "dev": true
         },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
+        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -408,24 +505,24 @@
             "dev": true
         },
         "tns-core-modules": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/tns-core-modules/-/tns-core-modules-3.4.0.tgz",
-            "integrity": "sha1-PEDdPpXGwzs/73rU7nTaqEOpKhE=",
+            "version": "6.5.20",
+            "resolved": "https://registry.npmjs.org/tns-core-modules/-/tns-core-modules-6.5.20.tgz",
+            "integrity": "sha512-AakBsQfYCOoZnJrRsBMdwjodwAEma64hXJ657HAhWT4mSDyohh4UI4/iEn+dOnJa6g4tf2+7d3AnihKYwx3WYg==",
             "dev": true,
             "requires": {
-                "tns-core-modules-widgets": "3.4.0"
+                "@nativescript/core": "6.5.20"
             }
         },
         "tns-core-modules-widgets": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/tns-core-modules-widgets/-/tns-core-modules-widgets-3.4.0.tgz",
-            "integrity": "sha512-WEtjDRTjjKB+C1NhY1CJSNyhK9DPCYzBgM+yKgq5AmphK/QdQEMAP1U2ttOv8yWWfsvLZGOnzyLCzcyeoG0Gfw==",
+            "version": "6.5.10",
+            "resolved": "https://registry.npmjs.org/tns-core-modules-widgets/-/tns-core-modules-widgets-6.5.10.tgz",
+            "integrity": "sha512-esZPbnm0wIn89AoFxdfhFuG0a/JE9A9k3ovBRpzs9O9d/JrChlgkTX4lSRQz6xBHLC1UVaqiTc/DNBGbdaeCyA==",
             "dev": true
         },
         "tns-platform-declarations": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/tns-platform-declarations/-/tns-platform-declarations-3.4.0.tgz",
-            "integrity": "sha1-JK/qs94J63O5mP2qSKKVx8Xyjns=",
+            "version": "6.5.15",
+            "resolved": "https://registry.npmjs.org/tns-platform-declarations/-/tns-platform-declarations-6.5.15.tgz",
+            "integrity": "sha512-gCUt2rjPTndp0K6xrgo6tFJvmkAsVOnIvebUUXMdLsNrJScs+OX4pL4DeIGMHGm/ciLqBlG5ZPkTOi8ZJCZuAQ==",
             "dev": true
         },
         "tslib": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-share-file",
-    "version": "1.0.6",
+    "version": "2.0.0",
     "description": "Send/share file to other apps.",
     "main": "share-file",
     "typings": "index.d.ts",
@@ -46,8 +46,8 @@
     "homepage": "https://github.com/braune-digital/nativescript-share-file",
     "readmeFilename": "README.md",
     "devDependencies": {
-        "tns-core-modules": "^3.1.0",
-        "tns-platform-declarations": "^3.1.0",
+        "tns-core-modules": "^6.5.15",
+        "tns-platform-declarations": "^6.5.15",
         "typescript": "~2.3.0",
         "prompt": "^1.0.0",
         "rimraf": "^2.5.0",

--- a/src/share-file.android.ts
+++ b/src/share-file.android.ts
@@ -1,51 +1,55 @@
-import * as application from 'tns-core-modules/application';
-import * as fs from 'tns-core-modules/file-system';
+import * as application from "tns-core-modules/application";
+import * as fs from "tns-core-modules/file-system";
 
 export class ShareFile {
-    open(args: any): void {
-      if (args.path) {
-        try {
-          let intent = new android.content.Intent();
+  open(args: any): void {
+    if (args.path) {
+      try {
+        let intent = new android.content.Intent();
 
-          intent.addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        intent.addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
-          let uris = new java.util.ArrayList();
-          let uri = this._getUriForPath(args.path);
-          uris.add(uri);
-          let builder = new android.os.StrictMode.VmPolicy.Builder();
-          android.os.StrictMode.setVmPolicy(builder.build());
+        let uris = new java.util.ArrayList();
+        let uri = this._getUriForPath(args.path);
+        uris.add(uri);
+        let builder = new android.os.StrictMode.VmPolicy.Builder();
+        android.os.StrictMode.setVmPolicy(builder.build());
 
-          intent.setAction(android.content.Intent.ACTION_SEND_MULTIPLE);
-          intent.setType("message/rfc822");
-          intent.putParcelableArrayListExtra(android.content.Intent.EXTRA_STREAM, uris);
+        intent.setAction(android.content.Intent.ACTION_SEND_MULTIPLE);
+        intent.setType("message/rfc822");
+        intent.putParcelableArrayListExtra(
+          android.content.Intent.EXTRA_STREAM,
+          uris
+        );
 
-          application.android.foregroundActivity.startActivity(android.content.Intent.createChooser(intent, args.intentTitle ? args.intentTitle : 'Open file:'));
-
-        }
-        catch (e) {
-            console.log('ShareFile: Android intent failed');
-        }
-      } else {
-        console.log('ShareFile: Please add a file path');
+        application.android.foregroundActivity.startActivity(
+          android.content.Intent.createChooser(
+            intent,
+            args.intentTitle ? args.intentTitle : "Open file:"
+          )
+        );
+      } catch (e) {
+        console.log("ShareFile: Android intent failed");
       }
-
+    } else {
+      console.log("ShareFile: Please add a file path");
     }
+  }
 
-    fileExtension(filename) {
-        return filename.split('.').pop();
-    }
-    fileName(filename) {
-        return filename.split('/').pop();
-    }
+  fileExtension(filename) {
+    return filename.split(".").pop();
+  }
+  fileName(filename) {
+    return filename.split("/").pop();
+  }
 
-    _getUriForPath(path, fileName, ctx) {
-      var file = new java.io.File(path);
-      return androidx.core.content.FileProvider.getUriForFile(
-        application.android.foregroundActivity ||
-          application.android.startActivity,
-        application.android.packageName + ".fileprovider",
-        file
-      );
-    }
-
+  _getUriForPath(path) {
+    var file = new java.io.File(path);
+    return androidx.core.content.FileProvider.getUriForFile(
+      application.android.foregroundActivity ||
+        application.android.startActivity,
+      application.android.packageName + ".fileprovider",
+      file
+    );
+  }
 }

--- a/src/share-file.android.ts
+++ b/src/share-file.android.ts
@@ -6,13 +6,11 @@ export class ShareFile {
       if (args.path) {
         try {
           let intent = new android.content.Intent();
-          let map = android.webkit.MimeTypeMap.getSingleton();
-          let mimeType = map.getMimeTypeFromExtension(this.fileExtension(args.path));
 
           intent.addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
           let uris = new java.util.ArrayList();
-          let uri = this._getUriForPath(args.path, '/' + this.fileName(args.path), application.android.context);
+          let uri = this._getUriForPath(args.path);
           uris.add(uri);
           let builder = new android.os.StrictMode.VmPolicy.Builder();
           android.os.StrictMode.setVmPolicy(builder.build());
@@ -41,85 +39,13 @@ export class ShareFile {
     }
 
     _getUriForPath(path, fileName, ctx) {
-        if (path.indexOf("file:///") === 0) {
-          return this._getUriForAbsolutePath(path);
-        } else if (path.indexOf("file://") === 0) {
-          return this._getUriForAssetPath(path, fileName, ctx);
-        } else if (path.indexOf("base64:") === 0) {
-          return this._getUriForBase64Content(path, fileName, ctx);
-        } else {
-          if (path.indexOf(ctx.getPackageName()) > -1) {
-            return this._getUriForAssetPath(path, fileName, ctx);
-          } else {
-            return this._getUriForAbsolutePath(path);
-          }
-        }
-      }
-       _getUriForAbsolutePath(path) {
-        let absPath = path.replace("file://", "");
-        let file = new java.io.File(absPath);
-        if (!file.exists()) {
-          console.log("File not found: " + file.getAbsolutePath());
-          return null;
-        } else {
-          return android.net.Uri.fromFile(file);
-        }
-      }
-       _getUriForAssetPath(path, fileName, ctx) {
-        path = path.replace("file://", "/");
-        if (!fs.File.exists(path)) {
-          console.log("File does not exist: " + path);
-          return null;
-        }
-        let localFile = fs.File.fromPath(path);
-        let localFileContents = localFile.readSync(function(e) { console.log(e); });
-        let cacheFileName = this._writeBytesToFile(ctx, fileName, localFileContents);
-        if (cacheFileName.indexOf("file://") === -1) {
-          cacheFileName = "file://" + cacheFileName;
-        }
-        return android.net.Uri.parse(cacheFileName);
-      }
-       _getUriForBase64Content(path, fileName, ctx) {
-        let resData = path.substring(path.indexOf("://") + 3);
-        let bytes;
-        try {
-          bytes = android.util.Base64.decode(resData, 0);
-        } catch (ex) {
-          console.log("Invalid Base64 string: " + resData);
-          return android.net.Uri.EMPTY;
-        }
-        let cacheFileName = this._writeBytesToFile(ctx, fileName, bytes);
-        return android.net.Uri.parse(cacheFileName);
-      }
-       _writeBytesToFile(ctx, fileName, contents) {
-        let dir = ctx.getExternalCacheDir();
-        if (dir === null) {
-          console.log("Missing external cache dir");
-          return null;
-        }
-        let storage = dir.toString() + "/filecomposer";
-        let cacheFileName = storage + "/" + fileName;
-        let toFile = fs.File.fromPath(cacheFileName);
-        toFile.writeSync(contents, function(e) { console.log(e); });
-        if (cacheFileName.indexOf("file://") === -1) {
-          cacheFileName = "file://" + cacheFileName;
-        }
-        return cacheFileName;
-      }
-    _cleanAttachmentFolder() {
-        if (application.android.context) {
-          let dir = application.android.context.getExternalCacheDir();
-          let storage = dir.toString() + "/filecomposer";
-          let cacheFolder = fs.Folder.fromPath(storage);
-          cacheFolder.clear();
-        }
-      }
-      toStringArray(arg) {
-        let arr = java.lang.reflect.Array.newInstance(java.lang.String.class, arg.length);
-        for (let i = 0; i < arg.length; i++) {
-          arr[i] = arg[i];
-        }
-        return arr;
-      }
+      var file = new java.io.File(path);
+      return androidx.core.content.FileProvider.getUriForFile(
+        application.android.foregroundActivity ||
+          application.android.startActivity,
+        application.android.packageName + ".fileprovider",
+        file
+      );
+    }
 
 }

--- a/src/share-file.android.ts
+++ b/src/share-file.android.ts
@@ -1,55 +1,50 @@
-import * as application from "tns-core-modules/application";
-import * as fs from "tns-core-modules/file-system";
+import * as application from 'tns-core-modules/application';
 
 export class ShareFile {
-  open(args: any): void {
-    if (args.path) {
-      try {
-        let intent = new android.content.Intent();
+    open(args: any): void {
+      if (args.path) {
+        try {
+          let intent = new android.content.Intent();
 
-        intent.addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION);
+          intent.addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
-        let uris = new java.util.ArrayList();
-        let uri = this._getUriForPath(args.path);
-        uris.add(uri);
-        let builder = new android.os.StrictMode.VmPolicy.Builder();
-        android.os.StrictMode.setVmPolicy(builder.build());
+          let uris = new java.util.ArrayList();
+          let uri = this._getUriForPath(args.path);
+          uris.add(uri);
+          let builder = new android.os.StrictMode.VmPolicy.Builder();
+          android.os.StrictMode.setVmPolicy(builder.build());
 
-        intent.setAction(android.content.Intent.ACTION_SEND_MULTIPLE);
-        intent.setType("message/rfc822");
-        intent.putParcelableArrayListExtra(
-          android.content.Intent.EXTRA_STREAM,
-          uris
-        );
+          intent.setAction(android.content.Intent.ACTION_SEND_MULTIPLE);
+          intent.setType("message/rfc822");
+          intent.putParcelableArrayListExtra(android.content.Intent.EXTRA_STREAM, uris);
 
-        application.android.foregroundActivity.startActivity(
-          android.content.Intent.createChooser(
-            intent,
-            args.intentTitle ? args.intentTitle : "Open file:"
-          )
-        );
-      } catch (e) {
-        console.log("ShareFile: Android intent failed");
+          application.android.foregroundActivity.startActivity(android.content.Intent.createChooser(intent, args.intentTitle ? args.intentTitle : 'Open file:'));
+
+        }
+        catch (e) {
+            console.log('ShareFile: Android intent failed');
+        }
+      } else {
+        console.log('ShareFile: Please add a file path');
       }
-    } else {
-      console.log("ShareFile: Please add a file path");
+
     }
-  }
 
-  fileExtension(filename) {
-    return filename.split(".").pop();
-  }
-  fileName(filename) {
-    return filename.split("/").pop();
-  }
+    fileExtension(filename) {
+        return filename.split('.').pop();
+    }
+    fileName(filename) {
+        return filename.split('/').pop();
+    }
 
-  _getUriForPath(path) {
-    var file = new java.io.File(path);
-    return androidx.core.content.FileProvider.getUriForFile(
-      application.android.foregroundActivity ||
-        application.android.startActivity,
-      application.android.packageName + ".fileprovider",
-      file
-    );
-  }
+    _getUriForPath(path) {
+          var file = new java.io.File(path);
+          return androidx.core.content.FileProvider.getUriForFile(
+              application.android.foregroundActivity ||
+              application.android.startActivity,
+              application.android.packageName + ".fileprovider",
+              file
+          );
+      }
+
 }


### PR DESCRIPTION
This fixes Android 11 and is cleaner code in general. Major version bump included because it now requires Android Manifest setup. Closes #15 